### PR TITLE
Check length of host group before erroring. Fix race condition

### DIFF
--- a/providers/host.rb
+++ b/providers/host.rb
@@ -61,7 +61,7 @@ action :create do
         # And now fetch the newly made group to be sure it worked
         # and for later use
         groups = connection.query(get_groups_request)
-        Chef::Log.error('Error creating groups, see Chef errors') if result.nil?
+        Chef::Log.error('Error creating groups, see Chef errors') if result.nil? || groups.length == 0
       elsif groups.length == 1
         Chef::Log.info "Group #{current_group} already exists"
       else


### PR DESCRIPTION
When multiple hosts run at the same time with a new host group,
a race condition occurs. All the hosts query and find that the
host group does not exist. They then all try to create the host
group. Only one will succeed, the others will get an api error.
If the group gets created/exists, the subuquent call to get the host
group will have one result.
